### PR TITLE
Disable exit button while cleaning and also shut up vscode

### DIFF
--- a/PACT_Interface.py
+++ b/PACT_Interface.py
@@ -163,6 +163,7 @@ class UiPACTMainWin(object):
             self.RegBT_CLEAN_PLUGINS.setStyleSheet("background-color: pink; border-radius: 5px; border: 1px solid gray;")  # type: ignore
             self.RegBT_CLEAN_PLUGINS.clicked.disconnect()  # type: ignore
             self.RegBT_CLEAN_PLUGINS.clicked.connect(self.stop_cleaning)  # type: ignore
+            self.RegBT_Exit.setEnabled(False)  # type: ignore
 
     def stop_delay_style(self):  # Cannot use time.sleep() to delay button change, must use QTimer.
         self.RegBT_CLEAN_PLUGINS.setEnabled(True)  # type: ignore
@@ -170,6 +171,7 @@ class UiPACTMainWin(object):
         self.RegBT_CLEAN_PLUGINS.setStyleSheet("background-color: lightblue; border-radius: 5px; border: 1px solid gray;")  # type: ignore
         self.RegBT_CLEAN_PLUGINS.clicked.disconnect()  # type: ignore
         self.RegBT_CLEAN_PLUGINS.clicked.connect(self.start_cleaning)  # type: ignore
+        self.RegBT_Exit.setEnabled(True)  # type: ignore
 
     def stop_cleaning(self):
         if self.thread is not None:

--- a/PACT_Start.py
+++ b/PACT_Start.py
@@ -128,14 +128,14 @@ print("=========================================================================
 
 @dataclass
 class Info:
-    MO2_EXE: Path = field(default_factory=Path)
-    MO2_PATH: Path = field(default_factory=Path)
-    XEDIT_EXE: Path = field(default_factory=Path)
-    XEDIT_PATH: Path = field(default_factory=Path)
-    LOAD_ORDER_TXT: Path = field(default_factory=Path)
-    LOAD_ORDER_PATH: Path = field(default_factory=Path)
-    XEDIT_LOG_TXT: Path = field(default_factory=Path)
-    XEDIT_EXC_LOG: Path = field(default_factory=Path)
+    MO2_EXE: str | Path = field(default_factory=Path)
+    MO2_PATH: str | Path = field(default_factory=Path)
+    XEDIT_EXE: str | Path = field(default_factory=Path)
+    XEDIT_PATH: str | Path = field(default_factory=Path)
+    LOAD_ORDER_TXT: str | Path = field(default_factory=Path)
+    LOAD_ORDER_PATH: str | Path = field(default_factory=Path)
+    XEDIT_LOG_TXT: str | Path = field(default_factory=Path)
+    XEDIT_EXC_LOG: str | Path = field(default_factory=Path)
 
 
 info = Info()
@@ -260,7 +260,8 @@ def run_xedit(xedit_exc_log, plugin_name):
 
     # Write proper bat command depending on XEDIT and MO2 selections.
     plugin_escape = plugin_name.replace("&", "^&").replace("+", "^+").replace("(", "^(").replace(")", "^)")  # Escape special characters for command line.
-
+    
+    bat_command = ""
     # If specific xedit (fnvedit, fo4edit, sseedit) executable is set.
     if MO2Mode and info.XEDIT_EXE.lower() in xedit_list_specific:
         bat_command = f'"{info.MO2_PATH}" run "{info.XEDIT_PATH}" -a "-QAC -autoexit -autoload \\"{plugin_escape}\\""'


### PR DESCRIPTION
I did this because clicking the button while the cleaning is considered running will just result in an unclean exit (basically a crash).
Currently the only way to re-enable it is to click the stop button.
I put it in the stop_delay_style function because I thought that's where it made sense to put it.

This also unintentionally carries a change from a different branch that changed the type declaration for the Info dataclass so that it "accepts" strings or Paths, I used the Union generic because `type | type` syntax is not implemented in python 3.9. This was done to assure the type checker that we know what we're doing.